### PR TITLE
[fix] syntax deprecation

### DIFF
--- a/stylesheets/base.less
+++ b/stylesheets/base.less
@@ -31,12 +31,12 @@
   color: @syntax-invisible-character-color;
 }
 
-.editor .search-results .marker .region {
+.editor .search-results .syntax--marker .region {
   background-color: transparent;
   border: @syntax-result-marker-color;
 }
 
-.editor .search-results .marker.current-result .region {
+.editor .search-results .syntax--marker.current-result .region {
   border: @syntax-result-marker-color-selected;
 }
 
@@ -52,148 +52,148 @@
   background-color: rgba(61, 61, 61, 0.33);
 }
 
-.comment {
+.syntax--comment {
   color: #6d6d6d;
 }
 
-.string {
+.syntax--string {
   color: #97d8ea;
 }
 
-.constant.numeric {
+.syntax--constant.syntax--numeric {
   color: #fc9354;
 }
 
-.constant.language {
+.syntax--constant.syntax--language {
   color: #fc9354;
 }
 
-.constant.character, .constant.other {
+.syntax--constant.syntax--character, .syntax--constant.syntax--other {
   color: #fc9354;
 }
 
-.variable {
+.syntax--variable {
 }
 
-.keyword {
+.syntax--keyword {
   color: #f63249;
 }
 
-.storage {
+.syntax--storage {
   color: #f63249;
 }
 
-.storage.type {
+.syntax--storage.syntax--type {
   font-style: italic;
   color: #73c3d2;
 }
 
-.entity.name.class {
+.syntax--entity.syntax--name.syntax--class {
   text-decoration: underline;
   color: #2e98e2;
 }
 
-.entity.other.inherited-class {
+.syntax--entity.syntax--other.syntax--inherited-class {
   font-style: italic;
   text-decoration: underline;
   color: #2e98e2;
 }
 
-.entity.name.function {
+.syntax--entity.syntax--name.syntax--function {
   color: #2e98e2;
 }
 
-.variable.parameter {
+.syntax--variable.syntax--parameter {
   font-style: italic;
   color: #fc9354;
 }
 
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag {
   color: #f63249;
 }
 
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
   color: #2e98e2;
 }
 
-.support.function {
+.syntax--support.syntax--function {
   color: #8ecfdb;
 }
 
-.support.constant {
+.syntax--support.syntax--constant {
   color: #8ecfdb;
 }
 
-.support.type, .support.class {
+.syntax--support.syntax--type, .syntax--support.syntax--class {
   font-style: italic;
   color: #8ecfdb;
 }
 
-.support.other.variable {
+.syntax--support.syntax--other.syntax--variable {
 }
 
-.support.other.namespace, .entity.name.type.namespace {
+.syntax--support.syntax--other.syntax--namespace, .syntax--entity.syntax--name.syntax--type.syntax--namespace {
   color: #FFB2F9;
 }
 
-.support.other.namespace.use-as.php {
+.syntax--support.syntax--other.syntax--namespace.syntax--use-as.syntax--php {
   color: #66D9EF;
 }
 
-.variable.language.namespace.php {
+.syntax--variable.syntax--language.syntax--namespace.syntax--php {
   color: #D66990;
 }
 
-.punctuation.separator.inheritance.php {
+.syntax--punctuation.syntax--separator.syntax--inheritance.syntax--php {
   color: #F92672;
 }
 
-.support.function.misc.css, .support.constant.property-value.css, .support.constant.font-name.css {
+.syntax--support.syntax--function.syntax--misc.syntax--css, .syntax--support.syntax--constant.syntax--property-value.syntax--css, .syntax--support.syntax--constant.syntax--font-name.syntax--css {
   color: #FFEE99;
 }
 
-.meta.tag.template.value.twig, .meta.tag.template.block.twig {
+.syntax--meta.syntax--tag.syntax--template.syntax--value.syntax--twig, .syntax--meta.syntax--tag.syntax--template.syntax--block.syntax--twig {
   color: #CD5AC5;
 }
 
-.keyword.control.twig {
+.syntax--keyword.syntax--control.syntax--twig {
   color: #E05D8C;
 }
 
-.variable.other.twig {
+.syntax--variable.syntax--other.syntax--twig {
   color: #E5A5E0;
 }
 
-.variable.other.property.twig {
+.syntax--variable.syntax--other.syntax--property.syntax--twig {
   color: #FFE1FC;
 }
 
-.constant.language.twig {
+.syntax--constant.syntax--language.syntax--twig {
   color: #FFD2A6;
 }
 
-.constant.numeric.twig {
+.syntax--constant.syntax--numeric.syntax--twig {
   color: #FFD0FB;
 }
 
-.support.function.twig {
+.syntax--support.syntax--function.syntax--twig {
   color: #90E7F7;
 }
 
-.meta.function-call.other.twig {
+.syntax--meta.syntax--function-call.syntax--other.syntax--twig {
   color: #FAB85A;
 }
 
-.meta.function-call.twig {
+.syntax--meta.syntax--function-call.syntax--twig {
   color: #FAB85A;
 }
 
-.invalid {
+.syntax--invalid {
   color: #F8F8F0;
   background-color: #f92649;
 }
 
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
   color: #F8F8F0;
   background-color: #FF80F4;
 }


### PR DESCRIPTION
Starting from Atom v1.13.0, **the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary**. This means you should stop using ```:host``` and ```::shadow``` pseudo-selectors, and prepend all your syntax selectors with ```syntax--```.